### PR TITLE
Add OSX test to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ matrix:
       env: TOX_ENV=flake8
     - python: 3.6
       env: TOX_ENV=py3flake8
+    - os: osx
+      language: generic
+      env: TOX_ENV=py27
+      osx_image: xcode7.3
     - python: 2.7
       env: TOX_ENV=py27
     - python: 3.4


### PR DESCRIPTION
This simply adds an OSx section to the test matrix.

`osx_image: xcode7.3` is explicitly used as it comes with pip and other dependencies built in.