### PR TITLE
Bugfix: Console formatter removes the original message from the record

### DIFF
--- a/wryte.py
+++ b/wryte.py
@@ -19,6 +19,7 @@ import json
 import socket
 import logging
 from datetime import datetime
+import logging.handlers
 
 try:
     # Python 2

--- a/wryte.py
+++ b/wryte.py
@@ -127,12 +127,6 @@ class ConsoleFormatter(logging.Formatter):
         level = record['level'] if record['type'] == 'log' else 'EVENT'
         message = record['message']
 
-        # We no longer need them as part of the dict.
-        dk = ('level', 'type', 'hostname', 'pid',
-              'name', 'message', 'timestamp')
-        for key in dk:
-            del record[key]
-
         if COLOR_ENABLED and self.color and not self.simple:
             level = str(self._get_level_color(level) + level + Style.RESET_ALL)
             timestamp = str(Fore.GREEN + timestamp + Style.RESET_ALL)


### PR DESCRIPTION
The console formatter deletes fields from the record reference, so any other formatters lose access to them.

Also there was a missing import for logging.handlers that crushed the execution when using the file handler. 