### PR TITLE
FEAT: Allow adding caller to log message's context

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -455,7 +455,7 @@ min-similarity-lines=4
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=10
+max-args=20
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20

--- a/README.md
+++ b/README.md
@@ -638,6 +638,21 @@ $ cat log.file
 
 ```
 
+### Including the caller in the log
+
+DO NOT use this in production. Finding the caller is a (relatively) CPU intensive process.
+
+By passing the `include_src` flag when instantiating the logger or by exporting `WRYTE_INCLUDE_SRC`, you can include the caller in your log message.
+
+e.g.
+
+```
+$ wryte info message
+2018-04-18T12:16:54.105146 - Wryte - INFO - message
+  src={'method': 'main', 'line': 740, 'file': '/home/nir0s/repos/nir0s/wryte/wryte.py'}
+```
+
+
 ## Performance
 
 I haven't performed a deep benchmark on Wryte yet and am waiting to finish an initial implementation I will feel comfortable with before doing so.

--- a/wryte.py
+++ b/wryte.py
@@ -161,7 +161,8 @@ class Wryte:
                  jsonify=False,
                  color=True,
                  simple=False,
-                 enable_ec2=False):
+                 enable_ec2=False,
+                 include_src=False):
         """Instantiate a logger instance.
 
         Either a JSON or a Console handler will be added to the logger
@@ -181,6 +182,7 @@ class Wryte:
         self.pretty = pretty
         self.color = color
         self.simple = simple
+        self.include_src = include_src
 
         self.logger = self._logger(self.logger_name)
         self._log = self._get_base(self.logger_name, hostname, enable_ec2)
@@ -301,6 +303,13 @@ class Wryte:
         log['message'] = message
         log['level'] = level.upper()
         log['timestamp'] = self._get_timestamp()
+        if self._env('INCLUDE_SRC') or self.include_src:
+            src = self.logger.findCaller()
+            log['src'] = {
+                'file': src[0],
+                'line': src[1],
+                'method': src[2],
+            }
 
         return log
 


### PR DESCRIPTION
This is configurable via both an env var and a constructor flag.