### PR TITLE
Nested logger context + refactoring

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest-cov = "*"
+pytest = "*"
+click = "*"
+
+[packages]
+wryte = {editable = true,path = "."}
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,163 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "2aea5fa1bf82a1e58c36b501c79d4834dc3b36af0d2ba38bc51ff38b586f0a19"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "index": "pypi",
+            "version": "==7.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
+            ],
+            "version": "==4.5.3"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
+            ],
+            "markers": "python_version > '2.7'",
+            "version": "==7.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+            ],
+            "version": "==0.12.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45",
+                "sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
+            ],
+            "index": "pypi",
+            "version": "==4.6.3"
+        },
+        "pytest-cov": {
+            "hashes": [
+                "sha256:2b097cde81a302e1047331b48cadacf23577e431b61e9c6f49a1170bbe3d3da6",
+                "sha256:e00ea4fdde970725482f1f35630d12f074e121a23801aabf2ae154ec6bdd343a"
+            ],
+            "index": "pypi",
+            "version": "==2.7.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "wryte": {
+            "editable": true,
+            "path": "."
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Note that the following documentation relates to the code currently in the maste
 * Enrich with AWS EC2 metadata (instance-id, instance-type, region and ipv4) if available
 * Easily provide contexual data
 * Context binding to prevent repetition
+* Nested logger context
 * Dynamic severity levels
 * Retroactive logging (WIP)
 * Assist in user tracing (via auto-provided context ids)
@@ -318,6 +319,22 @@ wryter.unbind('user_id')
 ```
 
 And just like with the logger itself, you can bind nested dicts, kwargs and JSON strings.
+### Nested logger context
+
+In many cases you want to bind some information specific to the context, without modifying the original binded parameters. Wryte supports this using the `nested` method:
+
+```python
+nested_wryter = wryter.nested(name='nested', {'user_id': framework.user}, key=value)
+```
+
+Alternatively `nested` can be used as a context manager:
+```python
+with wryter.nested(stage='some-stage', requestId=uuid.uuid4()) as wryter:
+    wryter.info('ooh nice the above key value pairs will be attached to any log message')
+```
+
+This is preferable to `bind` as there is no need to `unbind`.
+
 #### Badly formatted context
 
 When providing a badly formatted context (e.g. `wryte.info('Message', ['bad_context'])`), a field containing the provided context will be added to the log like so:

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,11 @@ setup(
     long_description=read('README.rst'),
     py_modules=['wryte'],
     entry_points={'console_scripts': ['wryte = wryte:main']},
+    tests_require=[
+        'pytest',   
+        'pytest-cov',
+        'click'
+    ],
     extras_require={
         'color': ['colorama'],
         'cli': ['click>=6.7'],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(*parts):
 
 setup(
     name='wryte',
-    version="0.3.1",
+    version="0.4.0",
     url='https://github.com/strigo/wryte',
     author='nir0s',
     author_email='ops@strigo.io',

--- a/tests/_test_perf.py
+++ b/tests/_test_perf.py
@@ -1,41 +1,27 @@
 from datetime import datetime
-
-import numpy
 import pytest
+import timeit
 
 import wryte
 from wryte import Wryte
+
+def average(numbers):
+    return sum(numbers) / float(len(numbers))
 
 
 class TestPerf(object):
     def _test_simple_message(self):
         w = Wryte(color=False, simple=True)
-
-        timing = []
-
-        for _ in range(5):
-            now = datetime.now()
-
-            for _ in range(10):
-                w.info('My Message')
-
-            timing.append((datetime.now() - now).total_seconds() * 1000.0)
-
+        results = timeit.repeat('w.info(\'My Message\')', repeat=5, number=1000, globals={'w': w})
         # This is just a benchmark. This should NEVER take this long.
-        assert numpy.average(timing[1:]) < 10
+        assert average(results) < 1
 
     def test_simple_context(self):
         w = Wryte(color=False)
 
-        timing = []
 
-        for _ in range(5):
-            now = datetime.now()
+        results = timeit.repeat("w.info('My Message', {'key': 'value'})", repeat=5, number=1000, globals={'w': w})
 
-            for _ in range(10):
-                w.info('My Message', {'key': 'value'})
-
-            timing.append((datetime.now() - now).total_seconds() * 1000.0)
 
         # This is just a benchmark. This should NEVER take this long.
-        assert numpy.average(timing[1:]) < 10
+        assert average(results) < 1

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -16,6 +16,7 @@ def benchmark(code, repeat=20, number=10000):
 
 benchmark('w.info("test message")')
 benchmark('w.info("test message with context", {"key": "value"})')
+benchmark('w.log("info", "test messge")')
 # without handlers, simple message
 # 648e0c2: ~260ms
 # 764dc31: ~260ms

--- a/tests/bench.py
+++ b/tests/bench.py
@@ -1,36 +1,21 @@
-from datetime import datetime
-
-import numpy
-
 from wryte import Wryte
+import timeit
+import statistics
 
+w = Wryte(color=False, simple=False)
+w.remove_handler('_console')
 
-def _test_simple_message(count):
-    w = Wryte(color=False, simple=False)
-    w.remove_handler('_console')
-    timing = []
+def benchmark(code, repeat=20, number=10000):
+    print('Benchmarking: `{}`'.format(code))
+    results = timeit.repeat(code, repeat=repeat, number=number, globals={'w': w})
+    avg = sum(results) / len(results)
+    p90 = sorted(results)[int(len(results)*0.9)]
+    print('20 iterations: ')
+    print('\n'.join(map(str, results)))
+    print('avg: {}, P90: {}'.format(statistics.mean(results), p90))
 
-    for _ in range(5):
-        now = datetime.now()
-
-        for _ in range(count):
-            w.info('My Message')
-
-        timing.append((datetime.now() - now).total_seconds() * 1000.0)
-
-    return numpy.average(timing[1:])
-
-
-avgs = []
-
-for _ in range(15):
-    result = _test_simple_message(10000)
-    avgs.append(result)
-    print(result)
-
-print('\navg of avgs:')
-print(numpy.average(avgs[1:]))
-
+benchmark('w.info("test message")')
+benchmark('w.info("test message with context", {"key": "value"})')
 # without handlers, simple message
 # 648e0c2: ~260ms
 # 764dc31: ~260ms

--- a/wryte.py
+++ b/wryte.py
@@ -344,14 +344,6 @@ class Wryte:
         if self._env('HANDLERS_ELASTICSEARCH_ENABLED'):
             self.add_elasticsearch_handler()
 
-    def _assert_level(self, level):
-        levels = LEVEL_CONVERSION.keys()
-
-        if level.lower() not in levels:
-            self.logger.exception('Level must be one of %s', levels)
-            return False
-        return True
-
     def add_handler(self,
                     handler,
                     name=None,
@@ -367,10 +359,7 @@ class Wryte:
         """
         name = name or str(uuid.uuid4())
 
-        if self._assert_level(level):
-            self.logger.setLevel(LEVEL_CONVERSION[level.lower()])
-        else:
-            return ''
+        self.logger.setLevel(LEVEL_CONVERSION[level.lower()])
 
         if formatter == 'json':
             _formatter = JsonFormatter(self.pretty or False)
@@ -549,9 +538,6 @@ class Wryte:
     def set_level(self, level):
         """Set the current logger instance's level.
         """
-        if not self._assert_level(level):
-            return
-
         self.logger.setLevel(level.upper())
 
     def bind(self, *objects, **kwargs):
@@ -602,12 +588,11 @@ class Wryte:
         can practically pass weird logging levels.
         """
         obj = self._enrich(message, level, objects, kwargs)
-        if '_set_level' in kwargs:
-            self.set_level(kwargs['_set_level'])
-
-        if not self._assert_level(level):
+        try:
+            level_num = LEVEL_CONVERSION[level]
+        except AttributeError:
             return
-        self.logger.log(LEVEL_CONVERSION[level], obj)
+        self.logger.log(level_num, obj)
 
     # Ideally, we'd use `self.log` for all of these, but since
     # level conversion would affect performance, it's better to now to


### PR DESCRIPTION
Slightly changed the API of wryte, hence the minor version bump:
- Added nested logger support, see `README.md`
- While logging-time methods should never blow up (wryte core principle?), config-time methods _should_ blow up. You don't want logger config to silently fail and leave you without any logs...