### PR TITLE
FEAT: Remove py3.5 testing and add 3.8 and 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,10 @@ workflows:
   version: 2
   test:
     jobs:
+      - test-3.9
+      - test-3.8
       - test-3.7
       - test-3.6
-      - test-3.5
       - test-pylint
       - test-black
 
@@ -46,12 +47,19 @@ jobs:
     environment:
       - TOX_ENV: py36
 
-  test-3.5:
+  test-3.8:
     <<: *test-template
     docker:
-      - image: cimg/python:3.5
+      - image: cimg/python:3.8
     environment:
-      - TOX_ENV: py35
+      - TOX_ENV: py38
+
+  test-3.9:
+    <<: *test-template
+    docker:
+      - image: cimg/python:3.9
+    environment:
+      - TOX_ENV: py39
 
   test-pylint:
     <<: *test-template

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,9 +2,7 @@
 .[color]
 tox==3.23.0
 pylint==2.7.2; python_version > '3.5'
-pylint==2.6.1; python_version == '3.5'
 pytest==6.2.2; python_version > '3.5'
-pytest==6.1.2; python_version == '3.5'
 pytest-cov==2.11.1
 pre-commit==2.11.1; python_version > '3.5'
 black==20.8b1; python_version > '3.5'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.15.0
-envlist = pylint, black, py35, py36, py37
+envlist = pylint, black, py36, py37, py38, py39
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
3.5 is EOL, and 3.8 and 3.9 have official stable releases.